### PR TITLE
NDS-790: ndslabs-startup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This repository contains startup scripts to run the Labs Workbench services on a
 
 ## Prerequisites
 * Git
-* Docker 1.9+
-* Wildcard DNS or etc hosts entry
+* Docker 1.9+ or Minikube
+* Wildcard DNS or /etc/hosts entry
 
-## Configuration
+## Getting Started
 Clone this repo, then set up desired instance parameters by editing the following ConfigMap:
 ```
 git clone https://github.com/nds-org/ndslabs-startup
@@ -25,7 +25,8 @@ cd ndslabs-startup/
 vi templates/config.yaml
 ```
 
-Customize your instance of workbench with the following options:
+### Configuration Options
+Within `templates/config.yaml` you can customize your instance of workbench with the following options:
 ```
 # Enable TLS (recommended)
 tls.enable: "true"
@@ -52,7 +53,8 @@ git.spec_repo: "https://github.com/nds-org/ndslabs-specs.git"
 git.spec_branch: "master"
 ```
 
-For futher customization, you can fork the entire [ndslabs repo](https://github.com/nds-org/ndslabs) and point these config options to override  anything in the UI source code.
+### Advanced Customization
+For futher customization, you can fork the entire [ndslabs repo](https://github.com/nds-org/ndslabs) and point these config options to your new fork, allowing you to override anything in the UI source code.
 ```
 # Drop-in a customized UI from git (custom CSS/HTML, new views, additional functionality, etc)
 git.dropin_repo: ""
@@ -60,18 +62,36 @@ git.dropin_branch: ""
 ```
 
 ## Kubernetes
-To start a local Kubernetes via hyperkube, simply run `./kube.sh`:
+There are multiple ways to run a local single-node Kubernetes cluster.
+
+Two of the most popular methods are [MiniKube](https://github.com/kubernetes/minikube) and Hyperkube.
+
+### Available Commands
+* `./kube.sh`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
+* `./kube.sh minikube`: Bring up a local Kubernetes cluster with [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), which spawns a local VM running Kubernetes
+* `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover Kuberenetes containers
+* `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the development environment (see below)
+* `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an ndslabs/deploy-tools container
+
+#### Via Minikube
+Minikube will run a local VM on your host machine that provides the Kubernetes services installed and running.
+
+First, you will need to download the [minikube](https://github.com/kubernetes/minikube) binary for your OS. Then, to start a local Kubernetes via minikube, simply run our provided `./kube.sh` with the appropriate command:
+```
+./kube.sh minikube
+```
+
+With the minikube container passed, this script just wraps around the `minikube start` command.
+
+#### Via Hyperkube
+Hyperkube will run a local Kubernetes cluster in several Docker containers all running on the host.
+
+To start a local Kubernetes via hyperkube, simply run our provided `./kube.sh`:
 ```
 ./kube.sh
 ```
 
 With no command passed, this will automatically start all necessary Kubernetes services running as separate Docker containers.
-
-### Available Commands
-* `./kube.sh`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
-* `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover Kuberenetes containers
-* `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the development environment (see below)
-* `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an ndslabs/deploy-tools container
 
 ## Labs Workbench
 To evaluate the Labs Workbench platform, simply run `./ndslabs.sh`:
@@ -100,3 +120,4 @@ It will then replace the running instace of ndslabs-webui with a version that re
 ### Available Commands
 * `./devenv.sh`: Start Kubernetes and Labs Workbench services, then bring up a development environment to modify the UI source
 * `./devenv.sh down`: Bring down development environment and swap running UI with static image
+

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ There are multiple ways to run a local single-node Kubernetes cluster.
 Two of the most popular methods are [MiniKube](https://github.com/kubernetes/minikube) and Hyperkube.
 
 ### Available Commands
-* `./kube.sh up`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
-* `./kube.sh minikube`: Bring up a local Kubernetes cluster with [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), which spawns a local VM running Kubernetes. Assumes that you have minikube installed and working (requires VirtualBox).
+* `./kube.sh`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
 * `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover Kuberenetes containers
 * `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the development environment (see below)
 * `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an ndslabs/deploy-tools container
@@ -76,12 +75,15 @@ Two of the most popular methods are [MiniKube](https://github.com/kubernetes/min
 #### Via Minikube
 Minikube will run a local VM on your host machine that provides the Kubernetes services installed and running.
 
-First, you will need to download the [minikube](https://github.com/kubernetes/minikube) binary for your OS. Then, to start a local Kubernetes via minikube, simply run our provided `./kube.sh` with the appropriate command:
+First, you will need to download the [minikube](https://github.com/kubernetes/minikube) binary for your OS. Then, to start a local Kubernetes via minikube, simply run:
 ```
-./kube.sh minikube
+minikube start
 ```
 
-With the minikube container passed, this script just wraps around the `minikube start` command.
+To stop Kubernetes via minikube:
+```
+minikube stop
+```
 
 #### Via Hyperkube
 Hyperkube will run a local Kubernetes cluster in several Docker containers all running on the host.
@@ -99,13 +101,13 @@ To evaluate the Labs Workbench platform, simply run `./ndslabs.sh`:
 ./ndslabs.sh
 ```
 
-With no command passed, this will automatically start all necessary Kubernetes and Labs Workbench components.
+With no command passed, this will automatically start Labs Workbench components.
 
 NOTE: assumes wildcard DNS is available, but you can add individual /etc/hosts entries if needed.
 
 ### Available Commands
-* `./ndslabs.sh`: Start Kubernetes, then bring all ndslabs services online
-* `./ndslabs.sh down`: Bring down all ndslabs services (but leaves Kubernetes running)
+* `./ndslabs.sh`: Start workbench services
+* `./ndslabs.sh down`: Bring down all workbench services (but leaves Kubernetes running)
 * `./ndslabs.sh apipass`: Print the Admin Password of the currently running ndslabs-apiserver pod to the console
 * `./ndslabs.sh apipasswd`: Alias for `./ndslabs.sh apipass`
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ There are multiple ways to run a local single-node Kubernetes cluster.
 Two of the most popular methods are [MiniKube](https://github.com/kubernetes/minikube) and Hyperkube.
 
 ### Available Commands
-* `./kube.sh`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
-* `./kube.sh minikube`: Bring up a local Kubernetes cluster with [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), which spawns a local VM running Kubernetes
+* `./kube.sh up`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
+* `./kube.sh minikube`: Bring up a local Kubernetes cluster with [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), which spawns a local VM running Kubernetes. Assumes that you have minikube installed and working (requires VirtualBox).
 * `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover Kuberenetes containers
 * `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the development environment (see below)
 * `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an ndslabs/deploy-tools container

--- a/devenv.sh
+++ b/devenv.sh
@@ -3,10 +3,12 @@
 export BINDIR="$HOME/bin"
 ECHO='echo -e'
 
+command="$(echo $1 | tr '[A-Z]' '[a-z]')"
+
 # Ensure that Kubernetes / Labs Workbench are running
 ./ndslabs.sh --api-only 
 
-if [ "${1,,}" == "down" ]; then
+if [ "$command" == "down" ]; then
     # Stop Dev version of webui and a cloud9 container
     $ECHO 'Stopping developer environment and UI...'
     $BINDIR/kubectl delete svc,rc ndslabs-webui
@@ -18,7 +20,7 @@ if [ "${1,,}" == "down" ]; then
 
 
 # If "basic-auth" is passed as a command, offer to regenerate the user's basic-auth secret 
-elif [ "${1,,}" == "basic-auth" ]; then
+elif [ "$command" == "basic-auth" ]; then
     kube_output="$($BINDIR/kubectl get secret -o name basic-auth 2>&1)"
     if [ "$kube_output" == "secret/basic-auth" ]; then
         read -p 'Secret "basic-auth" exists. Regenerate it? [y/N] ' regenerate

--- a/devenv.sh
+++ b/devenv.sh
@@ -16,9 +16,49 @@ if [ "${1,,}" == "down" ]; then
     $ECHO 'Starting production Labs Workbench UI...'
     $BINDIR/kubectl create -f templates/core/webui.yaml
 
+
+# If "basic-auth" is passed as a command, offer to regenerate the user's basic-auth secret 
+elif [ "${1,,}" == "basic-auth" ]; then
+    kube_output="$($BINDIR/kubectl get secret -o name basic-auth 2>&1)"
+    if [ "$kube_output" == "secret/basic-auth" ]; then
+        read -p 'Secret "basic-auth" exists. Regenerate it? [y/N] ' regenerate
+        if [ "${regenerate:0:1}" != "y" -a "${regenerate:0:1}" != "Y" ]; then
+            exit 1
+        fi
+
+        $BINDIR/kubectl delete secret basic-auth
+    fi
+
+
+    read -p "Username: " username
+    if [ ! -n "$username" ]; then
+        $ECHO 'No username entered... Aborting'
+        exit 1
+    fi
+
+    read -s -p "Password: " password
+    if [ ! -n "$password" ]; then
+        $ECHO 'No password entered... Aborting'
+        exit 1
+    fi
+    $ECHO ""
+
+    read -s -p "Confirm password: " password_confirm
+    if [ ! -n "$password_confirm" -o "$password" != "$password_confirm" ]; then
+        $ECHO 'Passwords did not match.'
+        exit 1
+    fi
+    $ECHO ""
+
+    # Duplicate stdout
+    auth="$(docker run -it --rm bodom0015/htpasswd -b -c /dev/stdout $username $password | tail -1)" 
+    $BINDIR/kubectl create secret generic basic-auth --from-literal=auth="$auth" 
+    
+ 
+    exit 0
 else
     # Ensure that user has created a basic-auth secret
-    $BINDIR/kubectl get secret basic-auth >/dev/null 2>&1 || $ECHO 'You will now be prompted for your desired credentials for basic-auth into Cloud9.' && ./kube.sh basic-auth
+    $BINDIR/kubectl get secret basic-auth >/dev/null 2>&1 || $ECHO 'You will now be prompted for your desired credentials for basic-auth into Cloud9.' && ./devenv.sh basic-auth
 
     # Notify user that source should be cloned to the correct location
     $ECHO "\nThe developer environment assumes that you have the ndslabs source code checked out at /home/core/ndslabs"

--- a/kube.sh
+++ b/kube.sh
@@ -69,6 +69,15 @@ if [ "${1,,}" == "basic-auth" ]; then
     exit 0
 fi
 
+# If "minikube" is passed as a command, run the "minikube start" command
+if [ "${1,,}" == "minikube" ]; then
+    minikube version || $ECHO 'Minikube binary must be installed to run Kubernetes Minikube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
+    
+    minikube start
+    
+    exit 0
+fi
+
 # If "deploy-tools" is passed as a command, start a container to remotely deploy Labs Workbench using Ansible
 # DEPRECATED: This will go away as we move toward kargo
 if [ "${1,,}" == "deploy-tools" ]; then
@@ -82,6 +91,7 @@ fi
 # By default, start Kubernetes via Hyperkube
 #
 $ECHO 'Starting Hyperkube Kubelet...'
+docker --version || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
 (docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \

--- a/kube.sh
+++ b/kube.sh
@@ -28,47 +28,6 @@ if [ "${1,,}" == "down" ]; then
     exit 0
 fi
 
-# If "basic-auth" is passed as a command, regenerate the user's basic-auth secret 
-if [ "${1,,}" == "basic-auth" ]; then
-    kube_output="$($BINDIR/kubectl get secret -o name basic-auth 2>&1)"
-    if [ "$kube_output" == "secret/basic-auth" ]; then
-        read -p 'Secret "basic-auth" exists. Regenerate it? [y/N] ' regenerate
-        if [ "${regenerate:0:1}" != "y" -a "${regenerate:0:1}" != "Y" ]; then
-            exit 1
-        fi
-
-        $BINDIR/kubectl delete secret basic-auth
-    fi
-
-
-    read -p "Username: " username
-    if [ ! -n "$username" ]; then
-        $ECHO 'No username entered... Aborting'
-        exit 1
-    fi
-
-    read -s -p "Password: " password
-    if [ ! -n "$password" ]; then
-        $ECHO 'No password entered... Aborting'
-        exit 1
-    fi
-    $ECHO ""
-
-    read -s -p "Confirm password: " password_confirm
-    if [ ! -n "$password_confirm" -o "$password" != "$password_confirm" ]; then
-        $ECHO 'Passwords did not match.'
-        exit 1
-    fi
-    $ECHO ""
-
-    # Duplicate stdout
-    auth="$(docker run -it --rm bodom0015/htpasswd -b -c /dev/stdout $username $password | tail -1)" 
-    $BINDIR/kubectl create secret generic basic-auth --from-literal=auth="$auth" 
-    
- 
-    exit 0
-fi
-
 # If "minikube" is passed as a command, run the "minikube start" command
 if [ "${1,,}" == "minikube" ]; then
     minikube version || $ECHO 'Minikube binary must be installed to run Kubernetes Minikube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1

--- a/kube.sh
+++ b/kube.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 export K8S_VERSION=1.5.1
 export BINDIR="$HOME/bin"
 ECHO='echo -e'
 
+command="$(echo $1 | tr '[A-Z]' '[a-z]')"
+
 # If "down" is given as the command, shut down hyperkube
-if [ "${1,,}" == "down" ]; then
+if [ "$command" == "down" ]; then
     # Warn user of consequences
     $ECHO 'WARNING: Shutting down Kubernetes will delete all containers running under Kubernetes?'
     $ECHO 'This will DELETE ALL CONTAINER DATA that is not stored on a peristent volume mount.\n'
@@ -29,17 +31,20 @@ if [ "${1,,}" == "down" ]; then
 fi
 
 # If "minikube" is passed as a command, run the "minikube start" command
-if [ "${1,,}" == "minikube" ]; then
-    minikube version || $ECHO 'Minikube binary must be installed to run Kubernetes Minikube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
-    
+if [ "$command" == "minikube" ]; then
+    $ECHO 'Starting Kubernetes Minikube...' 
+    minikube version >/dev/null 2>&1 || ($ECHO 'Minikube binary must be installed to run Kubernetes Minikube. If you prefer to use hyperkube, please run ./kube.sh.' && exit 1)
+   
     minikube start
-    
+    $ECHO 'Kubernetes has started!'
+    $ECHO 'You can access your cluster using the kubectl binary.'    
+
     exit 0
 fi
 
 # If "deploy-tools" is passed as a command, start a container to remotely deploy Labs Workbench using Ansible
 # DEPRECATED: This will go away as we move toward kargo
-if [ "${1,,}" == "deploy-tools" ]; then
+if [ "$command" == "deploy-tools" ]; then
     docker run -it --name deploy-tools -v `pwd`/deploy-tools:/root/SAVED_AND_SENSITIVE_VOLUME ndslabs/deploy-tools:latest bash
 
     exit 0
@@ -50,7 +55,7 @@ fi
 # By default, start Kubernetes via Hyperkube
 #
 $ECHO 'Starting Hyperkube Kubelet...'
-docker --version || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
+docker --version >/dev/null 2>&1 || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
 (docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \

--- a/kube.sh
+++ b/kube.sh
@@ -30,18 +30,6 @@ if [ "$command" == "down" ]; then
     exit 0
 fi
 
-# If "minikube" is passed as a command, run the "minikube start" command
-if [ "$command" == "minikube" ]; then
-    $ECHO 'Starting Kubernetes Minikube...' 
-    minikube version >/dev/null 2>&1 || ($ECHO 'Minikube binary must be installed to run Kubernetes Minikube. If you prefer to use hyperkube, please run ./kube.sh.' && exit 1)
-   
-    minikube start
-    $ECHO 'Kubernetes has started!'
-    $ECHO 'You can access your cluster using the kubectl binary.'    
-
-    exit 0
-fi
-
 # If "deploy-tools" is passed as a command, start a container to remotely deploy Labs Workbench using Ansible
 # DEPRECATED: This will go away as we move toward kargo
 if [ "$command" == "deploy-tools" ]; then
@@ -55,7 +43,7 @@ fi
 # By default, start Kubernetes via Hyperkube
 #
 $ECHO 'Starting Hyperkube Kubelet...'
-docker --version >/dev/null 2>&1 || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run ./kube.sh minikube command.' && exit 1
+docker --version >/dev/null 2>&1 || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1
 (docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \

--- a/kube.sh
+++ b/kube.sh
@@ -43,7 +43,7 @@ fi
 # By default, start Kubernetes via Hyperkube
 #
 $ECHO 'Starting Hyperkube Kubelet...'
-docker --version >/dev/null 2>&1 || $ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1
+docker --version >/dev/null 2>&1 || ($ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1)
 (docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \

--- a/ndslabs.sh
+++ b/ndslabs.sh
@@ -3,6 +3,8 @@
 export BINDIR="$HOME/bin"
 ECHO='echo -e'
 
+command="$(echo $1 | tr '[A-Z]' '[a-z]')"
+
 # Helper function to start all Labs Workbench services
 # $1 == seconds to wait between probe attempts
 # $@ == all other args of parent are passed in (if "--api-only" is present, we skip starting the ui)
@@ -100,10 +102,10 @@ function stop_all() {
     $ECHO 'All Labs Workbench services stopped!'
 }
 
-if [ "${1,,}" == "apipass" -o "${1,,}" == "apipasswd" ]; then
+if [ "$command" == "apipass" -o "$command" == "apipasswd" ]; then
     # If "apipass" or "apipasswd" is passed as the command, print the API server Admin Password to stdout
     kubectl exec -it `kubectl get pods | grep apiserver | grep Running | awk '{print $1}'` cat /password.txt
-elif [ "${1,,}" == "down" ]; then
+elif [ "$command" == "down" ]; then
     # If "down" is passed as the command, stop Labs Workbench
     stop_all
 else


### PR DESCRIPTION
* Wrapped `minikube start` in a `./kube.sh minikube` command
* Moved basic-auth command from `./kube.sh` to `./devenv.sh`
* Updated documentation to add notes about minikube vs hyperkube

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-790