### PR TITLE
NDS-635: Changed to use custom default backend

### DIFF
--- a/templates/core/loadbalancer.yaml
+++ b/templates/core/loadbalancer.yaml
@@ -30,7 +30,7 @@ spec:
   selector:
     app: default-http-backend
   ports:
-    - port: 8080
+    - port: 80
       protocol: TCP
 ---
 apiVersion: v1
@@ -52,16 +52,16 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: ndslabs/ndslabs-default-backend:latest
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: 80
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
         ports:
-        - containerPort: 8080
+        - containerPort: 80
         resources:
           limits:
             cpu: 10m
@@ -76,6 +76,7 @@ data:
   ssl-protocols: "TLSv1.2"
   proxy-read-timeout: "300"
   proxy-send-timeout: "300"
+  custom-http-errors: "503"
 kind: ConfigMap
 metadata:
   name: nginx-ingress-conf

--- a/templates/core/loadbalancer.yaml
+++ b/templates/core/loadbalancer.yaml
@@ -77,6 +77,7 @@ data:
   proxy-read-timeout: "300"
   proxy-send-timeout: "300"
   custom-http-errors: "503"
+  body-size: 50m
 kind: ConfigMap
 metadata:
   name: nginx-ingress-conf


### PR DESCRIPTION
https://opensource.ncsa.illinois.edu/jira/browse/NDS-635
* Use custom default backend (https://hub.docker.com/r/ndslabs/ndslabs-default-backend/)
* Custom error page for 503