### PR TITLE
NDS-1008 NDSLabs Startup Script Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ For futher customization, you can fork the entire [ndslabs
 repo](https://github.com/nds-org/ndslabs) and point these config options to your
 new fork, allowing you to override anything in the UI source code.
 ```
-# Drop-in a customized UI from git (custom CSS/HTML, new views, additional functionality, etc)
+# Drop-in a customized UI from git (custom CSS/HTML, new views, additional
+functionality, etc)
 git.dropin_repo: ""
 git.dropin_branch: ""
 ```
@@ -111,23 +112,25 @@ With no command passed, this will automatically start all necessary Kubernetes
 services running as separate Docker containers.
 
 ## Labs Workbench
-To evaluate the Labs Workbench platform, simply run `./ndslabs.sh`:
-```
-./ndslabs.sh
-```
+To evaluate the Labs Workbench platform, simply run `./ndslabs.sh up`
 
-With no command passed, this will automatically start Labs Workbench components.
+This will start all of the required Labs components in your local Kubernetes
+cluster.
 
 NOTE: assumes wildcard DNS is available, but you can add individual /etc/hosts
 entries if needed.
 
 ### Available Commands
-* `./ndslabs.sh`: Start workbench services
-* `./ndslabs.sh down`: Bring down all workbench services (but leaves Kubernetes
-  running)
-* `./ndslabs.sh apipass`: Print the Admin Password of the currently running
+* `./ndslabs.sh up`: Start workbench services
+* `./ndslabs.sh down`: Bring down all workbench services
+(but leaves Kubernetes running)
+* `./ndslabs.sh print-passwd`: Print the Admin Password of the currently running
 ndslabs-apiserver pod to the console
-* `./ndslabs.sh apipasswd`: Alias for `./ndslabs.sh apipass`
+
+
+### Command line options
+* `--no-ui`: Start up the API and supporting services, but don't launch the web
+service
 
 ## Development Environment (Optional)
 ```
@@ -148,4 +151,4 @@ with static image
 # Gotchas
 * Your node must have the label **ndslabs-role-compute=true** in order for the
 * Labs Workbench API server to successfully schedule services there. NOTE: the
-* `./ndslabs` script handles this for you, by default.
+* `./ndslabs.sh up` script handles this for you, by default.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ ndslabs-apiserver pod to the console
 ### Command line options
 * `--no-ui`: Start up the API and supporting services, but don't launch the web
 service
+* `--start-bind`: Start up a local bind server to host wildcard domains on the
+local workstation. This is not needed if you are running with an external DNS
+that has wildcard domains (`*.foo.com`) pointing to the host that is running
+the workstation.
+
 
 ## Development Environment (Optional)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Labs Workbench Developer Startup
 
-This repository contains startup scripts to run the Labs Workbench services on a single developer node. This includes:
+This repository contains startup scripts to run the Labs Workbench services on a
+single developer node. This includes:
 * Small Kubernetes cluster via Docker containers
 * Nginx ingress controller
 * Labs Workbench etcd and SMTP servers
@@ -10,7 +11,7 @@ This repository contains startup scripts to run the Labs Workbench services on a
 ## Minimum System Requirements
 * 2 CPUs
 * 2+ GB RAM
-* 40+ GB storage 
+* 40+ GB storage
 
 ## Prerequisites
 * Git
@@ -18,7 +19,8 @@ This repository contains startup scripts to run the Labs Workbench services on a
 * Wildcard DNS or /etc/hosts entry
 
 ## Getting Started
-Clone this repo, then set up desired instance parameters by editing the following ConfigMap:
+Clone this repo, then set up desired instance parameters by editing the
+following ConfigMap:
 ```
 git clone https://github.com/nds-org/ndslabs-startup
 cd ndslabs-startup/
@@ -26,7 +28,8 @@ vi templates/config.yaml
 ```
 
 ### Configuration Options
-Within `templates/config.yaml` you can customize your instance of workbench with the following options:
+Within `templates/config.yaml` you can customize your instance of workbench with
+the following options:
 ```
 # Enable TLS (recommended)
 tls.enable: "true"
@@ -54,7 +57,9 @@ git.spec_branch: "master"
 ```
 
 ### Advanced Customization
-For futher customization, you can fork the entire [ndslabs repo](https://github.com/nds-org/ndslabs) and point these config options to your new fork, allowing you to override anything in the UI source code.
+For futher customization, you can fork the entire [ndslabs
+repo](https://github.com/nds-org/ndslabs) and point these config options to your
+new fork, allowing you to override anything in the UI source code.
 ```
 # Drop-in a customized UI from git (custom CSS/HTML, new views, additional functionality, etc)
 git.dropin_repo: ""
@@ -64,18 +69,26 @@ git.dropin_branch: ""
 ## Kubernetes
 There are multiple ways to run a local single-node Kubernetes cluster.
 
-Two of the most popular methods are [MiniKube](https://github.com/kubernetes/minikube) and Hyperkube.
+Two of the most popular methods are
+[MiniKube](https://github.com/kubernetes/minikube) and Hyperkube.
 
 ### Available Commands
-* `./kube.sh`: Bring up a local Kubernetes cluster with [hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md) which uses Docker to run the other Kubernetes microservices as containers.
-* `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover Kuberenetes containers
-* `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the development environment (see below)
-* `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an ndslabs/deploy-tools container
+* `./kube.sh`: Bring up a local Kubernetes cluster with
+[hyperkube](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md)
+which uses Docker to run the other Kubernetes microservices as containers.
+* `./kube.sh down`: Bring down all Kubernetes services and deletes all leftover
+Kuberenetes containers
+* `./kube.sh basic-auth`: Generate a new basic-auth secret for use with the
+development environment (see below)
+* `./kube.sh deploy-tools`: (DEPRECATED) Shortcut for running an
+ndslabs/deploy-tools container
 
 #### Via Minikube
-Minikube will run a local VM on your host machine that provides the Kubernetes services installed and running.
+Minikube will run a local VM on your host machine that provides the Kubernetes
+services installed and running.
 
-First, you will need to download the [minikube](https://github.com/kubernetes/minikube) binary for your OS. Then, to start a local Kubernetes via minikube, simply run:
+First, you will need to download the [minikube](https://github.com/kubernetes/minikube)
+binary for your OS. Then, to start a local Kubernetes via minikube, simply run:
 ```
 minikube start
 ```
@@ -86,14 +99,16 @@ minikube stop
 ```
 
 #### Via Hyperkube
-Hyperkube will run a local Kubernetes cluster in several Docker containers all running on the host.
+Hyperkube will run a local Kubernetes cluster in several Docker containers all
+running on the host.
 
 To start a local Kubernetes via hyperkube, simply run our provided `./kube.sh`:
 ```
 ./kube.sh
 ```
 
-With no command passed, this will automatically start all necessary Kubernetes services running as separate Docker containers.
+With no command passed, this will automatically start all necessary Kubernetes
+services running as separate Docker containers.
 
 ## Labs Workbench
 To evaluate the Labs Workbench platform, simply run `./ndslabs.sh`:
@@ -103,12 +118,15 @@ To evaluate the Labs Workbench platform, simply run `./ndslabs.sh`:
 
 With no command passed, this will automatically start Labs Workbench components.
 
-NOTE: assumes wildcard DNS is available, but you can add individual /etc/hosts entries if needed.
+NOTE: assumes wildcard DNS is available, but you can add individual /etc/hosts
+entries if needed.
 
 ### Available Commands
 * `./ndslabs.sh`: Start workbench services
-* `./ndslabs.sh down`: Bring down all workbench services (but leaves Kubernetes running)
-* `./ndslabs.sh apipass`: Print the Admin Password of the currently running ndslabs-apiserver pod to the console
+* `./ndslabs.sh down`: Bring down all workbench services (but leaves Kubernetes
+  running)
+* `./ndslabs.sh apipass`: Print the Admin Password of the currently running
+ndslabs-apiserver pod to the console
 * `./ndslabs.sh apipasswd`: Alias for `./ndslabs.sh apipass`
 
 ## Development Environment (Optional)
@@ -116,12 +134,18 @@ NOTE: assumes wildcard DNS is available, but you can add individual /etc/hosts e
 ./devenv.sh
 ```
 
-With no command passed, this will automatically generate a basic-auth secret and start up a Cloud9 IDE to use to for development.
-It will then replace the running instace of ndslabs-webui with a version that reflects changes made dynamicly from within Cloud9.
+With no command passed, this will automatically generate a basic-auth secret and
+start up a Cloud9 IDE to use to for development. It will then replace the
+running instace of ndslabs-webui with a version that reflects changes made
+dynamicly from within Cloud9.
 
 ### Available Commands
-* `./devenv.sh`: Start Kubernetes and Labs Workbench services, then bring up a development environment to modify the UI source
-* `./devenv.sh down`: Bring down development environment and swap running UI with static image
+* `./devenv.sh`: Start Kubernetes and Labs Workbench services, then bring up a
+development environment to modify the UI source
+* `./devenv.sh down`: Bring down development environment and swap running UI
+with static image
 
 # Gotchas
-* Your node must have the label **ndslabs-role-compute=true** in order for the Labs Workbench API server to successfully schedule services there. NOTE: the `./ndslabs` script handles this for you, by default.
+* Your node must have the label **ndslabs-role-compute=true** in order for the
+* Labs Workbench API server to successfully schedule services there. NOTE: the
+* `./ndslabs` script handles this for you, by default.

--- a/README.md
+++ b/README.md
@@ -29,32 +29,12 @@ vi templates/config.yaml
 
 ### Configuration Options
 Within `templates/config.yaml` you can customize your instance of workbench with
-the following options:
-```
-# Enable TLS (recommended)
-tls.enable: "true"
+several options. The only required change is to set `workbench.domain` domain to
+match wildcarded domain hosted on your server.
 
-# Enable account approval by configuring a target SMTP server, or use our provided G-Mail relay
-workbench.require_account_approval: "false"
-
-# To use the G-Mail SMTP relay, you will need to provide a set of credentials
-# See https://support.google.com/accounts/answer/185833?hl=en
-smtp.gmail_user: "YourGmailUsername"
-smtp.gmail_pass: "YouGeneratedAppPassword"
-
-# Customize the product name as it appears in the UI
-workbench.name: "Labs Workbench"
-
-# Customize support e-mail that help requests are sent to
-workbench.support_email: "support@example.com"
-
-# Customize Google Analytics tracking ID
-workbench.analytics_tracking_id: ""
-
-# Customize the JSON catalog of tools offered by this instance
-git.spec_repo: "https://github.com/nds-org/ndslabs-specs.git"
-git.spec_branch: "master"
-```
+In the case where a local bind is needed, you'd need to set `workbench.ip` to
+point an IP that your browser can access, then modify your local /etc/hosts and
+DNS settings to point to this same IP).
 
 ### Advanced Customization
 For futher customization, you can fork the entire [ndslabs

--- a/devenv.sh
+++ b/devenv.sh
@@ -6,7 +6,7 @@ ECHO='echo -e'
 command="$(echo $1 | tr '[A-Z]' '[a-z]')"
 
 # Ensure that Kubernetes / Labs Workbench are running
-./ndslabs.sh --api-only 
+./ndslabs.sh up --no-ui
 
 if [ "$command" == "down" ]; then
     # Stop Dev version of webui and a cloud9 container
@@ -19,7 +19,7 @@ if [ "$command" == "down" ]; then
     $BINDIR/kubectl create -f templates/core/webui.yaml
 
 
-# If "basic-auth" is passed as a command, offer to regenerate the user's basic-auth secret 
+# If "basic-auth" is passed as a command, offer to regenerate the user's basic-auth secret
 elif [ "$command" == "basic-auth" ]; then
     kube_output="$($BINDIR/kubectl get secret -o name basic-auth 2>&1)"
     if [ "$kube_output" == "secret/basic-auth" ]; then
@@ -53,12 +53,12 @@ elif [ "$command" == "basic-auth" ]; then
     $ECHO ""
 
     # Duplicate stdout
-    auth="$(docker run -it --rm bodom0015/htpasswd -b -c /dev/stdout $username $password | tail -1)" 
-    $BINDIR/kubectl create secret generic basic-auth --from-literal=auth="$auth" 
-    
- 
+    auth="$(docker run -it --rm bodom0015/htpasswd -b -c /dev/stdout $username $password | tail -1)"
+    $BINDIR/kubectl create secret generic basic-auth --from-literal=auth="$auth"
+
+
     exit 0
-else
+  elif [ "$command" == "up" ]; then
     # Ensure that user has created a basic-auth secret
     $BINDIR/kubectl get secret basic-auth >/dev/null 2>&1 || $ECHO 'You will now be prompted for your desired credentials for basic-auth into Cloud9.' && ./devenv.sh basic-auth
 
@@ -89,6 +89,9 @@ else
     $ECHO "https://cloud9.$DOMAIN"
     $ECHO "Any changes made here will be reflected on disk and mapped into the webui container"
     $ECHO "\nNOTE: Your basic-auth secret will be needed to authenticate you into this Cloud9 instance.\n"
+  else
+    $ECHO 'Labs Workbench Developer Environment usage: devenv.sh [up|down|basic-auth]'
+    exit 0
 fi
 
 # Wait for the UI server to start

--- a/kube.sh
+++ b/kube.sh
@@ -8,36 +8,35 @@ command="$(echo $1 | tr '[A-Z]' '[a-z]')"
 
 # If "down" is given as the command, shut down hyperkube
 if [ "$command" == "down" ]; then
-    # Warn user of consequences
-    $ECHO 'WARNING: Shutting down Kubernetes will delete all containers running under Kubernetes?'
-    $ECHO 'This will DELETE ALL CONTAINER DATA that is not stored on a peristent volume mount.\n'
+  # Warn user of consequences
+  $ECHO 'WARNING: Shutting down Kubernetes will delete all containers running under Kubernetes?'
+  $ECHO 'This will DELETE ALL CONTAINER DATA that is not stored on a peristent volume mount.\n'
 
-    # Confirm that user knows what they're doing.
-    read -p 'Are you sure you want to continue? [y/N] ' confirm_shutdown
-    if [ "${confirm_shutdown:0:1}" != "y" -a "${confirm_shutdown:0:1}" != "Y" ]; then
-        exit 1
-    fi
+  # Confirm that user knows what they're doing.
+  read -p 'Are you sure you want to continue? [y/N] ' confirm_shutdown
+  if [ "${confirm_shutdown:0:1}" != "y" -a "${confirm_shutdown:0:1}" != "Y" ]; then
+    exit 1
+  fi
 
-    # Remove kubelet first, or else it will continue to respawn killed containers
-    $ECHO 'Stopping Kubelet...'
-    docker stop kubelet >/dev/null 2>&1
+  # Remove kubelet first, or else it will continue to respawn killed containers
+  $ECHO 'Stopping Kubelet...'
+  docker stop kubelet >/dev/null 2>&1
 
-    # Use at your own risk: stop and remove all k8s Docker containers
-    $ECHO 'Cleaning up leftover Kubernetes resources...'
-    docker rm -f $(docker ps -a | grep k8s | awk  '{print $1}') >/dev/null 2>&1
-    $ECHO 'Kubernetes has been shutdown!'
+  # Use at your own risk: stop and remove all k8s Docker containers
+  $ECHO 'Cleaning up leftover Kubernetes resources...'
+  docker rm -f $(docker ps -a | grep k8s | awk '{print $1}') >/dev/null 2>&1
+  $ECHO 'Kubernetes has been shutdown!'
 
-    exit 0
+  exit 0
 fi
 
 # If "deploy-tools" is passed as a command, start a container to remotely deploy Labs Workbench using Ansible
 # DEPRECATED: This will go away as we move toward kargo
 if [ "$command" == "deploy-tools" ]; then
-    docker run -it --name deploy-tools -v `pwd`/deploy-tools:/root/SAVED_AND_SENSITIVE_VOLUME ndslabs/deploy-tools:latest bash
+  docker run -it --name deploy-tools -v $(pwd)/deploy-tools:/root/SAVED_AND_SENSITIVE_VOLUME ndslabs/deploy-tools:latest bash
 
-    exit 0
+  exit 0
 fi
-
 
 #
 # By default, start Kubernetes via Hyperkube
@@ -45,46 +44,46 @@ fi
 $ECHO 'Starting Hyperkube Kubelet...'
 docker --version >/dev/null 2>&1 || ($ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1)
 (docker run \
-	--restart=always \
-    --volume=/:/rootfs:ro \
-    --volume=/sys:/sys:ro \
-    --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
-    --volume=/var/run:/var/run:rw \
-    --volume=`pwd`/manifests:/etc/kubernetes/manifests \
-    --net=host \
-    --pid=host \
-    --privileged=true \
-    --name=kubelet \
-    -d \
-    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
-    /hyperkube kubelet \
-        --containerized \
-        --hostname-override="127.0.0.1" \
-        --address="0.0.0.0" \
-        --api-servers=http://localhost:8080 \
-        --config=/etc/kubernetes/manifests \
-	--allow-privileged=true --v=2 \
-        >/dev/null 2>&1 \
-    || docker start kubelet >/dev/null 2>&1)
+  --restart=always \
+  --volume=/:/rootfs:ro \
+  --volume=/sys:/sys:ro \
+  --volume=/var/lib/docker/:/var/lib/docker:rw \
+  --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
+  --volume=/var/run:/var/run:rw \
+  --volume=$(pwd)/manifests:/etc/kubernetes/manifests \
+  --net=host \
+  --pid=host \
+  --privileged=true \
+  --name=kubelet \
+  -d \
+  gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+  /hyperkube kubelet \
+  --containerized \
+  --hostname-override="127.0.0.1" \
+  --address="0.0.0.0" \
+  --api-servers=http://localhost:8080 \
+  --config=/etc/kubernetes/manifests \
+  --allow-privileged=true --v=2 \
+  >/dev/null 2>&1 \
+  || docker start kubelet >/dev/null 2>&1)
 $ECHO 'Waiting for Kubernetes API server to start on port 8080...'
 
 #
 # Download kubectl, if necessary
 #
 if [ ! -d "$BINDIR" ]; then
-    mkdir -p $BINDIR
-    $ECHO "Downloading kubectl binary to $BINDIR..."
-    curl http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl -o ~/bin/kubectl
-    chmod +x ~/bin/kubectl
+  mkdir -p $BINDIR
+  $ECHO "Downloading kubectl binary to $BINDIR..."
+  curl http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl -o ~/bin/kubectl
+  chmod +x ~/bin/kubectl
 
-    # TODO: Need an elegant way to add bins to PATH programmatically
-    export PATH="$BINDIR:$PATH"
-    $ECHO "Be sure to execute 'export PATH=$BINDIR:\$PATH' to add the directory contaning kubectl to your PATH."
+  # TODO: Need an elegant way to add bins to PATH programmatically
+  export PATH="$BINDIR:$PATH"
+  $ECHO "Be sure to execute 'export PATH=$BINDIR:\$PATH' to add the directory contaning kubectl to your PATH."
 fi
 
 # Wait for Kubernetes to start
-until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do   
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
   $ECHO 'Trying again in 5 seconds...'
   sleep 5s # wait for 5s before checking again
   kube_output=$($BINDIR/kubectl get pods)

--- a/kube.sh
+++ b/kube.sh
@@ -5,6 +5,9 @@ export BINDIR="$HOME/bin"
 ECHO='echo -e'
 
 command="$(echo $1 | tr '[A-Z]' '[a-z]')"
+if [ "$command" != "up" -a "$command" != "down" -a "$command" != "deploy-tools" ]; then
+    echo "Usage: kube.sh up|down|deploy-tools"
+fi
 
 # If "down" is given as the command, shut down hyperkube
 if [ "$command" == "down" ]; then
@@ -38,56 +41,56 @@ if [ "$command" == "deploy-tools" ]; then
   exit 0
 fi
 
-#
-# By default, start Kubernetes via Hyperkube
-#
-$ECHO 'Starting Hyperkube Kubelet...'
-docker --version >/dev/null 2>&1 || ($ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1)
-(docker run \
-  --restart=always \
-  --volume=/:/rootfs:ro \
-  --volume=/sys:/sys:ro \
-  --volume=/var/lib/docker/:/var/lib/docker:rw \
-  --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
-  --volume=/var/run:/var/run:rw \
-  --volume=$(pwd)/manifests:/etc/kubernetes/manifests \
-  --net=host \
-  --pid=host \
-  --privileged=true \
-  --name=kubelet \
-  -d \
-  gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
-  /hyperkube kubelet \
-  --containerized \
-  --hostname-override="127.0.0.1" \
-  --address="0.0.0.0" \
-  --api-servers=http://localhost:8080 \
-  --config=/etc/kubernetes/manifests \
-  --allow-privileged=true --v=2 \
-  >/dev/null 2>&1 \
-  || docker start kubelet >/dev/null 2>&1)
-$ECHO 'Waiting for Kubernetes API server to start on port 8080...'
+if [ "$command" == "up" ]; then
+  $ECHO 'Starting Hyperkube Kubelet...'
+  docker --version >/dev/null 2>&1 || ($ECHO 'Docker must be installed to run Kubernetes Hyperkube. If you prefer to use minikube, please run minikube command.' && exit 1)
+  (docker run \
+    --restart=always \
+    --volume=/:/rootfs:ro \
+    --volume=/sys:/sys:ro \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,rslave \
+    --volume=/var/run:/var/run:rw \
+    --volume=$(pwd)/manifests:/etc/kubernetes/manifests \
+    --net=host \
+    --pid=host \
+    --privileged=true \
+    --name=kubelet \
+    -d \
+    gcr.io/google_containers/hyperkube-amd64:v${K8S_VERSION} \
+    /hyperkube kubelet \
+    --containerized \
+    --hostname-override="127.0.0.1" \
+    --address="0.0.0.0" \
+    --api-servers=http://localhost:8080 \
+    --config=/etc/kubernetes/manifests \
+    --allow-privileged=true --v=2 \
+    >/dev/null 2>&1 \
+    || docker start kubelet >/dev/null 2>&1)
+  $ECHO 'Waiting for Kubernetes API server to start on port 8080...'
 
-#
-# Download kubectl, if necessary
-#
-if [ ! -d "$BINDIR" ]; then
-  mkdir -p $BINDIR
-  $ECHO "Downloading kubectl binary to $BINDIR..."
-  curl http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl -o ~/bin/kubectl
-  chmod +x ~/bin/kubectl
+  #
+  # Download kubectl, if necessary
+  #
+  if [ ! -d "$BINDIR" ]; then
+    mkdir -p $BINDIR
+    $ECHO "Downloading kubectl binary to $BINDIR..."
+    curl http://storage.googleapis.com/kubernetes-release/release/v${K8S_VERSION}/bin/linux/amd64/kubectl -o ~/bin/kubectl
+    chmod +x ~/bin/kubectl
 
-  # TODO: Need an elegant way to add bins to PATH programmatically
-  export PATH="$BINDIR:$PATH"
-  $ECHO "Be sure to execute 'export PATH=$BINDIR:\$PATH' to add the directory contaning kubectl to your PATH."
+    # TODO: Need an elegant way to add bins to PATH programmatically
+    export PATH="$BINDIR:$PATH"
+    $ECHO "Be sure to execute 'export PATH=$BINDIR:\$PATH' to add the directory contaning kubectl to your PATH."
+  fi
+
+  # Wait for Kubernetes to start
+  until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
+    $ECHO 'Trying again in 5 seconds...'
+    sleep 5s # wait for 5s before checking again
+    kube_output=$($BINDIR/kubectl get pods)
+  done
+
+  $ECHO 'Kubernetes has started!'
+  $ECHO 'You can access your cluster using the kubectl binary.'
+  exit 0
 fi
-
-# Wait for Kubernetes to start
-until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
-  $ECHO 'Trying again in 5 seconds...'
-  sleep 5s # wait for 5s before checking again
-  kube_output=$($BINDIR/kubectl get pods)
-done
-
-$ECHO 'Kubernetes has started!'
-$ECHO 'You can access your cluster using the kubectl binary.'

--- a/ndslabs.sh
+++ b/ndslabs.sh
@@ -33,6 +33,7 @@ echo "KUBECTL $KUBECTL_BIN"
 # Helper function to start all Labs Workbench services
 # $1 == seconds to wait between probe attempts
 # $2 == Flag whether to start the UI too
+# $3 == Flag whether to start our own bind service
 function start_all() {
   # Ensure that Kubernetes is running
   $KUBECTL_BIN create -f templates/config.yaml >/dev/null 2>&1
@@ -176,6 +177,11 @@ for i in "$@"; do
       shift # past argument with no value
       ;;
 
+    --start-bind)
+      START_BIND=YES
+      shift # past argument with no value
+      ;;
+
     *) # unknown option
       echo "Unknown commnad line option: $i"
       exit
@@ -193,11 +199,11 @@ case $OPERATION in
     ;;
 
   UP)
-    start_all 15 $START_UI
+    start_all 15 $START_UI $START_BIND
     ;;
 
   *)
-    echo "Usage: ndslabs.sh up|down|print-passwd  [--no-ui]"
+    echo "Usage: ndslabs.sh up|down|print-passwd  [--no-ui] [--start-bind]"
     ;;
 esac
 exit 0

--- a/ndslabs.sh
+++ b/ndslabs.sh
@@ -9,120 +9,119 @@ command="$(echo $1 | tr '[A-Z]' '[a-z]')"
 # $1 == seconds to wait between probe attempts
 # $@ == all other args of parent are passed in (if "--api-only" is present, we skip starting the ui)
 function start_all() {
-    # Ensure that Kubernetes is running
-    $BINDIR/kubectl create -f templates/config.yaml >/dev/null 2>&1
+  # Ensure that Kubernetes is running
+  $BINDIR/kubectl create -f templates/config.yaml >/dev/null 2>&1
 
-    # Grab our DOMAIN from the configmap
-    DOMAIN="$(cat templates/config.yaml | grep domain | awk '{print $2}' | sed s/\"//g)"
-    $ECHO "Starting Labs Workbench:"
-    $ECHO "    DOMAIN=$DOMAIN"
+  # Grab our DOMAIN from the configmap
+  DOMAIN="$(cat templates/config.yaml | grep domain | awk '{print $2}' | sed s/\"//g)"
+  $ECHO "Starting Labs Workbench:"
+  $ECHO "    DOMAIN=$DOMAIN"
 
-    # Generate self-signed TLS certs
-    if [ ! -f "certs/${DOMAIN}.cert" ]; then
-       $ECHO "\nGenerating self-signed certificate for $DOMAIN"
-       mkdir -p certs && \
-       openssl genrsa 2048 > certs/${DOMAIN}.key && \
-       openssl req -new -x509 -nodes -sha1 -days 3650 -subj "/C=US/ST=IL/L=Champaign/O=NCSA/OU=NDS/CN=*.$DOMAIN" -key "certs/${DOMAIN}.key" -out "certs/${DOMAIN}.cert"
-    fi
+  # Generate self-signed TLS certs
+  if [ ! -f "certs/${DOMAIN}.cert" ]; then
+    $ECHO "\nGenerating self-signed certificate for $DOMAIN"
+    mkdir -p certs \
+      && openssl genrsa 2048 >certs/${DOMAIN}.key \
+      && openssl req -new -x509 -nodes -sha1 -days 3650 -subj "/C=US/ST=IL/L=Champaign/O=NCSA/OU=NDS/CN=*.$DOMAIN" -key "certs/${DOMAIN}.key" -out "certs/${DOMAIN}.cert"
+  fi
 
-    # Create secret from TLS certs
-    $ECHO '\nGenerating Labs Workbench TLS Secret...'
-    $BINDIR/kubectl create secret generic ndslabs-tls-secret --from-file=tls.crt="certs/${DOMAIN}.cert" --from-file=tls.key="certs/${DOMAIN}.key" --namespace=default
-    $BINDIR/kubectl create secret generic ndslabs-tls-secret --from-file=tls.crt="certs/${DOMAIN}.cert" --from-file=tls.key="certs/${DOMAIN}.key" --namespace=kube-system
+  # Create secret from TLS certs
+  $ECHO '\nGenerating Labs Workbench TLS Secret...'
+  $BINDIR/kubectl create secret generic ndslabs-tls-secret --from-file=tls.crt="certs/${DOMAIN}.cert" --from-file=tls.key="certs/${DOMAIN}.key" --namespace=default
+  $BINDIR/kubectl create secret generic ndslabs-tls-secret --from-file=tls.crt="certs/${DOMAIN}.cert" --from-file=tls.key="certs/${DOMAIN}.key" --namespace=kube-system
 
-    $ECHO '\nStarting Labs Workbench core services...'
+  $ECHO '\nStarting Labs Workbench core services...'
 
-    # Pre-process jinja-style variables by piping through sed
-    cat templates/core/loadbalancer.yaml | sed -e "s#{{[ ]*DOMAIN[ ]*}}#$DOMAIN#g" | kubectl create -f -
-    $BINDIR/kubectl create -f templates/smtp/ -f templates/core/svc.yaml -f templates/core/etcd.yaml -f templates/core/apiserver.yaml -f templates/core/bind.yaml
+  # Pre-process jinja-style variables by piping through sed
+  cat templates/core/loadbalancer.yaml | sed -e "s#{{[ ]*DOMAIN[ ]*}}#$DOMAIN#g" | kubectl create -f -
+  $BINDIR/kubectl create -f templates/smtp/ -f templates/core/svc.yaml -f templates/core/etcd.yaml -f templates/core/apiserver.yaml -f templates/core/bind.yaml
 
-    # Label this as compute node, so that the ndslabs-apiserver can schedule pods here
-    nodename=$($BINDIR/kubectl get nodes | grep -v NAME | awk '{print $1}')
-    $BINDIR/kubectl label nodes ${nodename} ndslabs-role-compute=true
-    
-    # Don't start the webui if we were given --api-only
-    if [[ "${@/--api-only/ }" == "$@" ]]; then
-        $ECHO '\nStarting Labs Workbench UI...'
-        $BINDIR/kubectl create -f templates/core/webui.yaml
-    fi
+  # Label this as compute node, so that the ndslabs-apiserver can schedule pods here
+  nodename=$($BINDIR/kubectl get nodes | grep -v NAME | awk '{print $1}')
+  $BINDIR/kubectl label nodes ${nodename} ndslabs-role-compute=true
 
-    # TODO: Add support/options for LMA stuff
-    # $ECHO '\nStarting Labs Workbench LMA tools...'
-    # $BINDIR/kubectl create -f templates/lma/nagios-nrpe-ds.yaml
+  # Don't start the webui if we were given --api-only
+  if [[ "${@/--api-only/ }" == "$@" ]]; then
+    $ECHO '\nStarting Labs Workbench UI...'
+    $BINDIR/kubectl create -f templates/core/webui.yaml
+  fi
 
-    # Wait for the API server to start
-    $ECHO '\nWaiting for Labs Workbench API server to start...'
+  # TODO: Add support/options for LMA stuff
+  # $ECHO '\nStarting Labs Workbench LMA tools...'
+  # $BINDIR/kubectl create -f templates/lma/nagios-nrpe-ds.yaml
 
-    BASE_URL=localhost
-    if  type "minikube" &> /dev/null  &&  minikube ip &> /dev/null ]]; then
-        BASE_URL=https://www.$DOMAIN/
-		$ECHO "\nDetected minikube instance, using $BASE_URL (requires /etc/hosts entry)\n"
-    fi
+  # Wait for the API server to start
+  $ECHO '\nWaiting for Labs Workbench API server to start...'
 
-     
-    until $(curl -k --output /dev/null --silent --fail --header "Host: www.$DOMAIN" $BASE_URL/api/); do
-        $ECHO "Trying again in ${1} seconds..."
-        sleep ${1}s # wait before checking again
+  BASE_URL=localhost
+  if type "minikube" &>/dev/null && minikube ip ]] &>/dev/null; then
+    BASE_URL=https://www.$DOMAIN/
+    $ECHO "\nDetected minikube instance, using $BASE_URL (requires /etc/hosts entry)\n"
+  fi
+
+  until $(curl -k --output /dev/null --silent --fail --header "Host: www.$DOMAIN" $BASE_URL/api/); do
+    $ECHO "Trying again in ${1} seconds..."
+    sleep ${1}s # wait before checking again
+  done
+  $ECHO 'Labs Workbench API server successfully started!'
+
+  if [[ "${@/--api-only/ }" == "$@" ]]; then
+    # Wait for the UI server to start
+    $ECHO '\nWaiting for Labs Workbench UI server to start...'
+    $ECHO '(NOTE: This can take a couple of minutes)'
+    until $(curl -k --output /dev/null --silent --fail --header "Host: www.$DOMAIN" $BASE_URL/); do
+      $ECHO "Trying again in ${1} seconds..."
+      sleep ${1}s # wait before checking again
     done
-    $ECHO 'Labs Workbench API server successfully started!'
-
-    if [[ "${@/--api-only/ }" == "$@" ]]; then
-        # Wait for the UI server to start
-        $ECHO '\nWaiting for Labs Workbench UI server to start...'
-        $ECHO '(NOTE: This can take a couple of minutes)'
-        until $(curl -k --output /dev/null --silent --fail --header "Host: www.$DOMAIN" $BASE_URL/); do
-            $ECHO "Trying again in ${1} seconds..."
-            sleep ${1}s # wait before checking again
-        done
-        $ECHO 'Labs Workbench UI successfully started!'
-        $ECHO "\nYou should now be able to access the Labs Workbench UI via:"
-        $ECHO "https://www.$DOMAIN"
-    fi
+    $ECHO 'Labs Workbench UI successfully started!'
+    $ECHO "\nYou should now be able to access the Labs Workbench UI via:"
+    $ECHO "https://www.$DOMAIN"
+  fi
 }
 
 # Helper function to stop all Labs Workbench services
 #   - takes no parameters
 function stop_all() {
-    # TODO: Add support/options for LMA stuff
-    # $ECHO 'Stopping Labs Workbench LMA tools...'
-    # $BINDIR/kubectl delete ds --namespace=kube-system nagios-nrpe >/dev/null 2>&1
+  # TODO: Add support/options for LMA stuff
+  # $ECHO 'Stopping Labs Workbench LMA tools...'
+  # $BINDIR/kubectl delete ds --namespace=kube-system nagios-nrpe >/dev/null 2>&1
 
-    $ECHO 'Stopping Labs Workbench UI and API'
-    $BINDIR/kubectl delete rc,svc ndslabs-webui ndslabs-apiserver >/dev/null 2>&1
+  $ECHO 'Stopping Labs Workbench UI and API'
+  $BINDIR/kubectl delete rc,svc ndslabs-webui ndslabs-apiserver >/dev/null 2>&1
 
-    $ECHO 'Stopping Labs Workbench core services...'
-    $BINDIR/kubectl delete rc,svc ndslabs-etcd ndslabs-smtp default-http-backend >/dev/null 2>&1
-    $BINDIR/kubectl delete rc nginx-ilb-rc >/dev/null 2>&1
-    $BINDIR/kubectl delete ingress ndslabs-ingress  >/dev/null 2>&1
-    $BINDIR/kubectl delete configmap nginx-ingress-conf >/dev/null 2>&1
+  $ECHO 'Stopping Labs Workbench core services...'
+  $BINDIR/kubectl delete rc,svc ndslabs-etcd ndslabs-smtp default-http-backend >/dev/null 2>&1
+  $BINDIR/kubectl delete rc nginx-ilb-rc >/dev/null 2>&1
+  $BINDIR/kubectl delete ingress ndslabs-ingress >/dev/null 2>&1
+  $BINDIR/kubectl delete configmap nginx-ingress-conf >/dev/null 2>&1
 
-    $ECHO 'Deleting Labs Workbench TLS Secret...'
-    $BINDIR/kubectl delete secret ndslabs-tls-secret --namespace=default >/dev/null 2>&1
-    $BINDIR/kubectl delete secret ndslabs-tls-secret --namespace=kube-system >/dev/null 2>&1
+  $ECHO 'Deleting Labs Workbench TLS Secret...'
+  $BINDIR/kubectl delete secret ndslabs-tls-secret --namespace=default >/dev/null 2>&1
+  $BINDIR/kubectl delete secret ndslabs-tls-secret --namespace=kube-system >/dev/null 2>&1
 
-    # Remove node label
-    nodename=$($BINDIR/kubectl get nodes | grep -v NAME | awk '{print $1}')
-    $BINDIR/kubectl label nodes  ${nodename} ndslabs-role-compute- >/dev/null 2>&1
+  # Remove node label
+  nodename=$($BINDIR/kubectl get nodes | grep -v NAME | awk '{print $1}')
+  $BINDIR/kubectl label nodes ${nodename} ndslabs-role-compute- >/dev/null 2>&1
 
-    # Remove Workbench ConfigMap
-    $BINDIR/kubectl delete configmap ndslabs-config >/dev/null 2>&1
-	 
-	# Stop bind/dns
-    $BINDIR/kubectl delete -f templates/core/bind.yaml >/dev/null 2>&1
+  # Remove Workbench ConfigMap
+  $BINDIR/kubectl delete configmap ndslabs-config >/dev/null 2>&1
 
-    $ECHO 'All Labs Workbench services stopped!'
-    $ECHO 'Remember to remove any DNS entries if using the Bind service'
+  # Stop bind/dns
+  $BINDIR/kubectl delete -f templates/core/bind.yaml >/dev/null 2>&1
+
+  $ECHO 'All Labs Workbench services stopped!'
+  $ECHO 'Remember to remove any DNS entries if using the Bind service'
 }
 
 if [ "$command" == "apipass" -o "$command" == "apipasswd" ]; then
-    # If "apipass" or "apipasswd" is passed as the command, print the API server Admin Password to stdout
-    kubectl exec -it `kubectl get pods | grep apiserver | grep Running | awk '{print $1}'` cat /password.txt
+  # If "apipass" or "apipasswd" is passed as the command, print the API server Admin Password to stdout
+  kubectl exec -it $(kubectl get pods | grep apiserver | grep Running | awk '{print $1}') cat /password.txt
 elif [ "$command" == "down" ]; then
-    # If "down" is passed as the command, stop Labs Workbench
-    stop_all
+  # If "down" is passed as the command, stop Labs Workbench
+  stop_all
 else
-    # By default and for all other command, start Labs Workbench
-    start_all   "15"    $@
+  # By default and for all other command, start Labs Workbench
+  start_all "15" $@
 fi
 
 exit 0


### PR DESCRIPTION
This PR makes it easier for new NDS developers to bring up a single node NDS Workbench instance. 

It makes it easier to install on servers that don't require a dedicated local DNS bind server and cleans up some errors that can arise in finding a version of kubectl.

This is a solution for #NDS-1008 

# Summary of Changes
* Reformatted the scripts for consistent style
* Created a more extensible framework for parsing command line options
* Enhanced the functionality for finding the local installation of kubectl without requiring the PATH change
* Made the startup of the Bind server optional to avoid errors on servers that don't require a private DNS bind
* Updated the documentation to make simple setup easier to find.