### PR TITLE
NDS-1127: Removed GIT_DROPIN envvars from webui

### DIFF
--- a/templates/core/webui.yaml
+++ b/templates/core/webui.yaml
@@ -39,16 +39,6 @@ spec:
               configMapKeyRef:
                 name: ndslabs-config
                 key: workbench.support_email
-          - name: GIT_DROPIN_REPO
-            valueFrom:
-              configMapKeyRef:
-                name: ndslabs-config
-                key: git.dropin_repo
-          - name: GIT_DROPIN_BRANCH
-            valueFrom:
-              configMapKeyRef:
-                name: ndslabs-config
-                key: git.dropin_branch
           - name: APISERVER_HOST
             value: "www.$(DOMAIN)"
           - name: APISERVER_PORT


### PR DESCRIPTION
See https://opensource.ncsa.illinois.edu/jira/browse/NDS-1127