### PR TITLE
Fix password generation for AccountCreation script

### DIFF
--- a/scripts/AccountCreation/account.py
+++ b/scripts/AccountCreation/account.py
@@ -39,6 +39,8 @@ def saltPassword(password):
 	apriPassword = apriPassword[apriPassword.index('$apr1$'):]
 	apriPassword = apriPassword.replace("\n", "")
 	apriPassword = apriPassword.replace("\r", "")
+        apriPassword = apriPassword.replace("\\n", "")
+        apriPassword = apriPassword.replace("\\r'", "")
 	return apriPassword
 
 


### PR DESCRIPTION
### Problem
Script generates passwords in etcd with additional characters. This prevents users from logging in, as their hashed password has control characters appended.

### Approach
Fix the logic that is supposed to replace the control characters at the end of the password string.

### How to Test
1. Run the script against an existing Workbench instance
2. Check etcd: `etcdctl get /ndslabs/accounts/user1/account`
    * Notice there are no special characters appended to the password field
    * Compare to master, which appended special characters to the end of the password field